### PR TITLE
Add maven compiler plugin and specify java 1.6 as source and target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,16 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <version>2.1.1</version>
             </plugin>
+	
+	    <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                    <compilerArgument>-proc:none</compilerArgument>
+                </configuration>
+            </plugin>
 
             <!-- Arquillian needs a version of surefire >= 2.9
              see https://community.jboss.org/wiki/WhatVersionOfSurefireShouldIUseToRunMyArquillianTestsInAMavenBuild -->


### PR DESCRIPTION
This plugin was needed to be able to compile the project in my linux env...ironment.  Otherwise maven was trying to compile source and target 1.3 and throwing all kinds of errors.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project cas-client: Compilation failure: Compilation failure:
[ERROR] /home/ryancarlson/Projects/cas-client/src/main/java/edu/yale/its/tp/cas/client/filter/LogoutTrapFilter.java:[35,25] error: for-each loops are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable for-each loops)
[ERROR] /home/ryancarlson/Projects/cas-client/src/main/java/edu/yale/its/tp/cas/client/filter/LogoutTrapFilter.java:[51,5] error: annotations are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable annotations)
[ERROR] /home/ryancarlson/Projects/cas-client/src/main/java/edu/yale/its/tp/cas/client/filter/CASFilter.java:[265,16] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable generics)
[ERROR] /home/ryancarlson/Projects/cas-client/src/main/java/edu/yale/its/tp/cas/client/filter/CASFilter.java:[381,27] error: for-each loops are not supported in -source 1.3
[ERROR] 
```
