### PR TITLE
Changes for docker-based apps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.ccci</groupId>
     <artifactId>cas-client-custom</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.5</version>
+    <version>2.1.6</version>
     <name>Cru CAS Client</name>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,18 @@
             <scope>provided</scope>
         </dependency>
 
+        <!--
+           for applications that wish to use the InfinispanLogoutStorage
+        -->
+        <dependency>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-core</artifactId>
+            <version>6.0.2.Final</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+
     </dependencies>
 
     <build>

--- a/src/main/java/edu/yale/its/tp/cas/client/filter/ArrayListLogoutStorage.java
+++ b/src/main/java/edu/yale/its/tp/cas/client/filter/ArrayListLogoutStorage.java
@@ -1,0 +1,19 @@
+package edu.yale.its.tp.cas.client.filter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ArrayListLogoutStorage implements LogoutStorage {
+
+    List<String> tickets = new ArrayList<String>();
+
+    @Override
+    public boolean contains(String ticket) {
+        return tickets.contains(ticket);
+    }
+
+    @Override
+    public void add(String ticket) {
+        tickets.add(ticket);
+    }
+}

--- a/src/main/java/edu/yale/its/tp/cas/client/filter/CASFilter.java
+++ b/src/main/java/edu/yale/its/tp/cas/client/filter/CASFilter.java
@@ -22,7 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
-import edu.yale.its.tp.cas.util.Parameters;
+import edu.yale.its.tp.cas.util.Configuration;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -294,10 +294,10 @@ public class CASFilter implements Filter
     {
         System.out.println("Initializing CASFilter");
 
-        casLogin = Parameters.getParameter(config, LOGIN_INIT_PARAM);
-        casValidate = Parameters.getParameter(config, VALIDATE_INIT_PARAM);
+        casLogin = Configuration.getParameter(config, LOGIN_INIT_PARAM);
+        casValidate = Configuration.getParameter(config, VALIDATE_INIT_PARAM);
 
-        String casServerUrlPrefix = Parameters.getParameter(config, CAS_SERVER_URL_PREFIX);
+        String casServerUrlPrefix = Configuration.getParameter(config, CAS_SERVER_URL_PREFIX);
         if (casServerUrlPrefix != null)
         {
             if (casLogin == null)
@@ -310,15 +310,15 @@ public class CASFilter implements Filter
             }
         }
 
-        casServiceUrl = Parameters.getParameter(config, SERVICE_INIT_PARAM);
-        String casAuthorizedProxy = Parameters.getParameter(config, AUTHORIZED_PROXY_INIT_PARAM);
-        casRenew = Boolean.valueOf(Parameters.getParameter(config, RENEW_INIT_PARAM)).booleanValue();
-        casServerName = Parameters.getParameter(config, SERVERNAME_INIT_PARAM);
-        casProxyCallbackUrl = Parameters.getParameter(config, PROXY_CALLBACK_INIT_PARAM);
-        casLogoutCallbackUrl = Parameters.getParameter(config, LOGOUT_CALLBACK_INIT_PARAM);
-        wrapRequest = Boolean.valueOf(Parameters.getParameter(config, WRAP_REQUESTS_INIT_PARAM)).booleanValue();
-        casGateway = Boolean.valueOf(Parameters.getParameter(config, GATEWAY_INIT_PARAM)).booleanValue();
-        remoteUserAttrib = Parameters.getParameter(config, REMOTE_USER_ATTRIB_INIT_PARAM);
+        casServiceUrl = Configuration.getParameter(config, SERVICE_INIT_PARAM);
+        String casAuthorizedProxy = Configuration.getParameter(config, AUTHORIZED_PROXY_INIT_PARAM);
+        casRenew = Boolean.valueOf(Configuration.getParameter(config, RENEW_INIT_PARAM)).booleanValue();
+        casServerName = Configuration.getParameter(config, SERVERNAME_INIT_PARAM);
+        casProxyCallbackUrl = Configuration.getParameter(config, PROXY_CALLBACK_INIT_PARAM);
+        casLogoutCallbackUrl = Configuration.getParameter(config, LOGOUT_CALLBACK_INIT_PARAM);
+        wrapRequest = Boolean.valueOf(Configuration.getParameter(config, WRAP_REQUESTS_INIT_PARAM)).booleanValue();
+        casGateway = Boolean.valueOf(Configuration.getParameter(config, GATEWAY_INIT_PARAM)).booleanValue();
+        remoteUserAttrib = Configuration.getParameter(config, REMOTE_USER_ATTRIB_INIT_PARAM);
 
 
         if (casGateway && Boolean.valueOf(casRenew).booleanValue()) { throw new ServletException(

--- a/src/main/java/edu/yale/its/tp/cas/client/filter/CASFilter.java
+++ b/src/main/java/edu/yale/its/tp/cas/client/filter/CASFilter.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import edu.yale.its.tp.cas.util.Parameters;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -289,17 +290,20 @@ public class CASFilter implements Filter
     public void init(FilterConfig config) throws ServletException
     {
         System.out.println("Initializing CASFilter");
-        casLogin = config.getInitParameter(LOGIN_INIT_PARAM);
-        casValidate = config.getInitParameter(VALIDATE_INIT_PARAM);
-        casServiceUrl = config.getInitParameter(SERVICE_INIT_PARAM);
-        String casAuthorizedProxy = config.getInitParameter(AUTHORIZED_PROXY_INIT_PARAM);
-        casRenew = Boolean.valueOf(config.getInitParameter(RENEW_INIT_PARAM)).booleanValue();
-        casServerName = config.getInitParameter(SERVERNAME_INIT_PARAM);
-        casProxyCallbackUrl = config.getInitParameter(PROXY_CALLBACK_INIT_PARAM);
-        casLogoutCallbackUrl = config.getInitParameter(LOGOUT_CALLBACK_INIT_PARAM);
-        wrapRequest = Boolean.valueOf(config.getInitParameter(WRAP_REQUESTS_INIT_PARAM)).booleanValue();
-        casGateway = Boolean.valueOf(config.getInitParameter(GATEWAY_INIT_PARAM)).booleanValue();
-        remoteUserAttrib = config.getInitParameter(REMOTE_USER_ATTRIB_INIT_PARAM);
+
+        casLogin = Parameters.getParameter(config, LOGIN_INIT_PARAM);
+        casValidate = Parameters.getParameter(config, VALIDATE_INIT_PARAM);
+
+        casServiceUrl = Parameters.getParameter(config, SERVICE_INIT_PARAM);
+        String casAuthorizedProxy = Parameters.getParameter(config, AUTHORIZED_PROXY_INIT_PARAM);
+        casRenew = Boolean.valueOf(Parameters.getParameter(config, RENEW_INIT_PARAM)).booleanValue();
+        casServerName = Parameters.getParameter(config, SERVERNAME_INIT_PARAM);
+        casProxyCallbackUrl = Parameters.getParameter(config, PROXY_CALLBACK_INIT_PARAM);
+        casLogoutCallbackUrl = Parameters.getParameter(config, LOGOUT_CALLBACK_INIT_PARAM);
+        wrapRequest = Boolean.valueOf(Parameters.getParameter(config, WRAP_REQUESTS_INIT_PARAM)).booleanValue();
+        casGateway = Boolean.valueOf(Parameters.getParameter(config, GATEWAY_INIT_PARAM)).booleanValue();
+        remoteUserAttrib = Parameters.getParameter(config, REMOTE_USER_ATTRIB_INIT_PARAM);
+
 
         if (casGateway && Boolean.valueOf(casRenew).booleanValue()) { throw new ServletException(
             "gateway and renew cannot both be true in filter configuration"); }

--- a/src/main/java/edu/yale/its/tp/cas/client/filter/CASFilter.java
+++ b/src/main/java/edu/yale/its/tp/cas/client/filter/CASFilter.java
@@ -197,6 +197,9 @@ public class CASFilter implements Filter
      */
     public final static String URL_PATTERN_EXCLUDE_INIT_PARAM = "url-pattern-exclude";
 
+    //CCCI
+    public final static String CAS_SERVER_URL_PREFIX = "casServerUrlPrefix";
+
     // Session attributes used by this filter
 
     /**
@@ -294,6 +297,19 @@ public class CASFilter implements Filter
         casLogin = Parameters.getParameter(config, LOGIN_INIT_PARAM);
         casValidate = Parameters.getParameter(config, VALIDATE_INIT_PARAM);
 
+        String casServerUrlPrefix = Parameters.getParameter(config, CAS_SERVER_URL_PREFIX);
+        if (casServerUrlPrefix != null)
+        {
+            if (casLogin == null)
+            {
+                casLogin = casServerUrlPrefix + "/login";
+            }
+            if (casValidate == null)
+            {
+                casValidate = casServerUrlPrefix + "/serviceValidate";
+            }
+        }
+
         casServiceUrl = Parameters.getParameter(config, SERVICE_INIT_PARAM);
         String casAuthorizedProxy = Parameters.getParameter(config, AUTHORIZED_PROXY_INIT_PARAM);
         casRenew = Boolean.valueOf(Parameters.getParameter(config, RENEW_INIT_PARAM)).booleanValue();
@@ -365,6 +381,7 @@ public class CASFilter implements Filter
         }
     }
 
+
     // *********************************************************************
     // Filter processing
 
@@ -416,7 +433,7 @@ public class CASFilter implements Filter
             fc.doFilter(wrapIfNecessary(request), response);
             return;
         }
-        
+
         // CCCI
         // Is this a request for logout? If so, process it
         if (!requestIsPost(request) && request.getParameter("ticket") != null && request.getParameter("ticket").startsWith("-"))
@@ -648,7 +665,7 @@ public class CASFilter implements Filter
 
     /**
      * CCCI
-     * 
+     *
      * @param request
      * @param response
      */
@@ -667,7 +684,7 @@ public class CASFilter implements Filter
 
     /**
      * CCCI
-     * 
+     *
      * @param receipt
      * @return
      */
@@ -679,13 +696,13 @@ public class CASFilter implements Filter
 
     /**
      * CCCI
-     * 
+     *
      * @param request
      * @param response
      */
     private void queueForLogout(ServletRequest request, ServletResponse response)
     {
-        if(requestIsPost(request)) return; 
+        if(requestIsPost(request)) return;
         String ticket = request.getParameter("ticket");
         ticket = ticket.substring(1); // remove the leading "-"
         logoutList.add(ticket);
@@ -696,7 +713,7 @@ public class CASFilter implements Filter
      * credentials that would have been acceptable to this path? Current
      * implementation checks whether from renew and whether proxy was
      * authorized.
-     * 
+     *
      * @param receipt
      * @return true if acceptable, false otherwise
      */
@@ -718,7 +735,7 @@ public class CASFilter implements Filter
      * Converts a ticket parameter to a CASReceipt, taking into account an
      * optionally configured trusted proxy in the tier immediately in front of
      * us.
-     * 
+     *
      * @throws ServletException
      *             - when unable to get service for request
      * @throws CASAuthenticationException

--- a/src/main/java/edu/yale/its/tp/cas/client/filter/CASFilter.java
+++ b/src/main/java/edu/yale/its/tp/cas/client/filter/CASFilter.java
@@ -317,16 +317,16 @@ public class CASFilter implements Filter
 
         casServiceUrl = Configuration.getParameter(config, SERVICE_INIT_PARAM);
         String casAuthorizedProxy = Configuration.getParameter(config, AUTHORIZED_PROXY_INIT_PARAM);
-        casRenew = Boolean.valueOf(Configuration.getParameter(config, RENEW_INIT_PARAM)).booleanValue();
+        casRenew = Boolean.valueOf(Configuration.getParameter(config, RENEW_INIT_PARAM));
         casServerName = Configuration.getParameter(config, SERVERNAME_INIT_PARAM);
         casProxyCallbackUrl = Configuration.getParameter(config, PROXY_CALLBACK_INIT_PARAM);
         casLogoutCallbackUrl = Configuration.getParameter(config, LOGOUT_CALLBACK_INIT_PARAM);
-        wrapRequest = Boolean.valueOf(Configuration.getParameter(config, WRAP_REQUESTS_INIT_PARAM)).booleanValue();
-        casGateway = Boolean.valueOf(Configuration.getParameter(config, GATEWAY_INIT_PARAM)).booleanValue();
+        wrapRequest = Boolean.valueOf(Configuration.getParameter(config, WRAP_REQUESTS_INIT_PARAM));
+        casGateway = Boolean.valueOf(Configuration.getParameter(config, GATEWAY_INIT_PARAM));
         remoteUserAttrib = Configuration.getParameter(config, REMOTE_USER_ATTRIB_INIT_PARAM);
 
 
-        if (casGateway && Boolean.valueOf(casRenew).booleanValue()) { throw new ServletException(
+        if (casGateway && Boolean.valueOf(casRenew)) { throw new ServletException(
             "gateway and renew cannot both be true in filter configuration"); }
         if (casServerName != null && casServiceUrl != null) { throw new ServletException(
             "serverName and serviceUrl cannot both be set: choose one."); }
@@ -504,7 +504,7 @@ public class CASFilter implements Filter
         {
             log.trace("CAS ticket was not present on request.");
             // did we go through the gateway already?
-            boolean didGateway = Boolean.valueOf((String) session.getAttribute(CAS_FILTER_GATEWAYED)).booleanValue();
+            boolean didGateway = Boolean.valueOf((String) session.getAttribute(CAS_FILTER_GATEWAYED));
 
             if (casLogin == null)
             {
@@ -772,7 +772,7 @@ public class CASFilter implements Filter
         pv.setCasValidateUrl(casValidate);
         pv.setServiceTicket(request.getParameter("ticket"));
         pv.setService(getService(request));
-        pv.setRenew(Boolean.valueOf(casRenew).booleanValue());
+        pv.setRenew(casRenew);
         if (casProxyCallbackUrl != null)
         {
             pv.setProxyCallbackUrl(casProxyCallbackUrl);

--- a/src/main/java/edu/yale/its/tp/cas/client/filter/CASFilter.java
+++ b/src/main/java/edu/yale/its/tp/cas/client/filter/CASFilter.java
@@ -544,24 +544,6 @@ public class CASFilter implements Filter
             }
         }
 
-        // CCCI
-        // if our attribute's already present and valid, pass through the filter
-        // chain
-        if (ticket == null && receipt != null && isReceiptAcceptable(receipt))
-        {
-            log.trace("CAS_FILTER_RECEIPT attribute was present and acceptable - passing  request through filter..");
-            if (session.getAttribute(CASFilter.CAS_FILTER_RECEIPT_IS_FRESH_BEFORE_REDIRECT) != null)
-            {
-                session.removeAttribute(CASFilter.CAS_FILTER_RECEIPT_IS_FRESH_BEFORE_REDIRECT);
-            }
-            else
-            {
-                session.removeAttribute(CASFilter.CAS_FILTER_RECEIPT_IS_FRESH);
-            }
-            fc.doFilter(wrapIfNecessary(request), response);
-            return;
-        }
-
         try
         {
             receipt = getAuthenticatedUser((HttpServletRequest) request);

--- a/src/main/java/edu/yale/its/tp/cas/client/filter/CASValidateFilter.java
+++ b/src/main/java/edu/yale/its/tp/cas/client/filter/CASValidateFilter.java
@@ -220,10 +220,10 @@ public class CASValidateFilter implements Filter
     {
         casValidate = config.getInitParameter(VALIDATE_INIT_PARAM);
         casServiceUrl = config.getInitParameter(SERVICE_INIT_PARAM);
-        casRenew = Boolean.valueOf(config.getInitParameter(RENEW_INIT_PARAM)).booleanValue();
+        casRenew = Boolean.valueOf(config.getInitParameter(RENEW_INIT_PARAM));
         casServerName = config.getInitParameter(SERVERNAME_INIT_PARAM);
         casProxyCallbackUrl = config.getInitParameter(PROXY_CALLBACK_INIT_PARAM);
-        wrapRequest = Boolean.valueOf(config.getInitParameter(WRAP_REQUESTS_INIT_PARAM)).booleanValue();
+        wrapRequest = Boolean.valueOf(config.getInitParameter(WRAP_REQUESTS_INIT_PARAM));
         remoteUserAttrib = config.getInitParameter(CASFilter.REMOTE_USER_ATTRIB_INIT_PARAM);
 
         if (casServerName != null && casServiceUrl != null) { throw new ServletException(
@@ -463,7 +463,7 @@ public class CASValidateFilter implements Filter
         pv.setCasValidateUrl(casValidate);
         pv.setServiceTicket(request.getParameter("ticket"));
         pv.setService(getService(request));
-        pv.setRenew(Boolean.valueOf(casRenew).booleanValue());
+        pv.setRenew(casRenew);
         if (casProxyCallbackUrl != null)
         {
             pv.setProxyCallbackUrl(casProxyCallbackUrl);

--- a/src/main/java/edu/yale/its/tp/cas/client/filter/InfinispanLogoutStorage.java
+++ b/src/main/java/edu/yale/its/tp/cas/client/filter/InfinispanLogoutStorage.java
@@ -1,0 +1,31 @@
+package edu.yale.its.tp.cas.client.filter;
+
+import org.infinispan.Cache;
+import org.infinispan.manager.CacheContainer;
+
+/**
+ * @author Matt Drees
+ */
+public class InfinispanLogoutStorage implements LogoutStorage
+{
+
+    private final Cache<String, Boolean> cache;
+
+    public InfinispanLogoutStorage(Object storage)
+    {
+        CacheContainer cacheContainer = (CacheContainer) storage;
+        cache = cacheContainer.getCache();
+    }
+
+    @Override
+    public boolean contains(String ticket)
+    {
+        return cache.containsKey(ticket);
+    }
+
+    @Override
+    public void add(String ticket)
+    {
+        cache.put(ticket, true);
+    }
+}

--- a/src/main/java/edu/yale/its/tp/cas/client/filter/LogoutStorage.java
+++ b/src/main/java/edu/yale/its/tp/cas/client/filter/LogoutStorage.java
@@ -1,0 +1,7 @@
+package edu.yale.its.tp.cas.client.filter;
+
+public interface LogoutStorage {
+
+    public boolean contains(String ticket);
+    public void add(String ticket);
+}

--- a/src/main/java/edu/yale/its/tp/cas/proxy/ProxyEchoFilter.java
+++ b/src/main/java/edu/yale/its/tp/cas/proxy/ProxyEchoFilter.java
@@ -21,7 +21,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
-import edu.yale.its.tp.cas.util.Parameters;
+import edu.yale.its.tp.cas.util.Configuration;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -67,7 +67,7 @@ public class ProxyEchoFilter implements Filter
         {
             log.trace("initializing ProxyExchoFilter using config " + config);
         }
-        String echoTargetsParam = Parameters.getParameter(config, INIT_PARAM_ECHO_TARGETS);
+        String echoTargetsParam = Configuration.getParameter(config, INIT_PARAM_ECHO_TARGETS);
         if (echoTargetsParam == null) { throw new ServletException(
             "The ProxyEchoFilter requires initialization parameter " + INIT_PARAM_ECHO_TARGETS
                     + " to be a whitespace delimited list of echo targets."); }

--- a/src/main/java/edu/yale/its/tp/cas/proxy/ProxyEchoFilter.java
+++ b/src/main/java/edu/yale/its/tp/cas/proxy/ProxyEchoFilter.java
@@ -21,6 +21,7 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 
+import edu.yale.its.tp.cas.util.Parameters;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -66,7 +67,7 @@ public class ProxyEchoFilter implements Filter
         {
             log.trace("initializing ProxyExchoFilter using config " + config);
         }
-        String echoTargetsParam = config.getInitParameter(INIT_PARAM_ECHO_TARGETS);
+        String echoTargetsParam = Parameters.getParameter(config, INIT_PARAM_ECHO_TARGETS);
         if (echoTargetsParam == null) { throw new ServletException(
             "The ProxyEchoFilter requires initialization parameter " + INIT_PARAM_ECHO_TARGETS
                     + " to be a whitespace delimited list of echo targets."); }

--- a/src/main/java/edu/yale/its/tp/cas/util/Configuration.java
+++ b/src/main/java/edu/yale/its/tp/cas/util/Configuration.java
@@ -11,9 +11,9 @@ import javax.servlet.FilterConfig;
 /**
  * @author Matt Drees
  */
-public class Parameters
+public class Configuration
 {
-    private static Log log = LogFactory.getLog(Parameters.class);
+    private static Log log = LogFactory.getLog(Configuration.class);
 
     public static String getParameter(FilterConfig config, String parameterName) {
         String jndiValue = jndiLookup(parameterName);
@@ -27,10 +27,10 @@ public class Parameters
         }
     }
 
-    private static String jndiLookup(String parameterName) {
+    public static <T> T jndiLookup(String parameterName) {
         String location = "java:comp/env/cas/" + parameterName;
         try {
-            return (String) new InitialContext().lookup(location);
+            return InitialContext.doLookup(location);
         } catch (NameNotFoundException e) {
             return null;
         } catch (NamingException e) {

--- a/src/main/java/edu/yale/its/tp/cas/util/LogoutEchoFilter.java
+++ b/src/main/java/edu/yale/its/tp/cas/util/LogoutEchoFilter.java
@@ -70,7 +70,7 @@ public class LogoutEchoFilter implements Filter
         {
             log.trace("initializing ProxyExchoFilter using config " + config);
         }
-        String echoTargetsParam = Parameters.getParameter(config, INIT_PARAM_ECHO_TARGETS);
+        String echoTargetsParam = Configuration.getParameter(config, INIT_PARAM_ECHO_TARGETS);
         if (echoTargetsParam == null) { throw new ServletException(
             "The ProxyEchoFilter requires initialization parameter " + INIT_PARAM_ECHO_TARGETS
                     + " to be a whitespace delimited list of echo targets."); }
@@ -80,7 +80,7 @@ public class LogoutEchoFilter implements Filter
             String target = st.nextToken();
             this.echoTargets.add(target);
         }
-        String continueChainParam = Parameters.getParameter(config, INIT_PARAM_CONTINUE_CHAIN);
+        String continueChainParam = Configuration.getParameter(config, INIT_PARAM_CONTINUE_CHAIN);
         if (continueChainParam != null)
         {
             this.continueChain = Boolean.parseBoolean(continueChainParam);

--- a/src/main/java/edu/yale/its/tp/cas/util/LogoutEchoFilter.java
+++ b/src/main/java/edu/yale/its/tp/cas/util/LogoutEchoFilter.java
@@ -23,6 +23,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
+import edu.yale.its.tp.cas.client.filter.InfinispanLogoutStorage;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -31,7 +32,10 @@ import org.apache.commons.logging.LogFactory;
  * <br/>
  * A filter to echo logout requests to other instances operating behind a load
  * balancer. This is copied from ProxyEchoFilter.
- * 
+ *
+ * This is useful if the host names of the other instances can be determined up-front.
+ * It is not needed when using {@link InfinispanLogoutStorage}.
+ *
  * @author andrew.petro@yale.edu
  * @author Nathan.Kopp@ccci.org
  * @author Matt Drees

--- a/src/main/java/edu/yale/its/tp/cas/util/LogoutEchoFilter.java
+++ b/src/main/java/edu/yale/its/tp/cas/util/LogoutEchoFilter.java
@@ -70,7 +70,7 @@ public class LogoutEchoFilter implements Filter
         {
             log.trace("initializing ProxyExchoFilter using config " + config);
         }
-        String echoTargetsParam = config.getInitParameter(INIT_PARAM_ECHO_TARGETS);
+        String echoTargetsParam = Parameters.getParameter(config, INIT_PARAM_ECHO_TARGETS);
         if (echoTargetsParam == null) { throw new ServletException(
             "The ProxyEchoFilter requires initialization parameter " + INIT_PARAM_ECHO_TARGETS
                     + " to be a whitespace delimited list of echo targets."); }
@@ -80,7 +80,7 @@ public class LogoutEchoFilter implements Filter
             String target = st.nextToken();
             this.echoTargets.add(target);
         }
-        String continueChainParam = config.getInitParameter(INIT_PARAM_CONTINUE_CHAIN);
+        String continueChainParam = Parameters.getParameter(config, INIT_PARAM_CONTINUE_CHAIN);
         if (continueChainParam != null)
         {
             this.continueChain = Boolean.parseBoolean(continueChainParam);

--- a/src/main/java/edu/yale/its/tp/cas/util/Parameters.java
+++ b/src/main/java/edu/yale/its/tp/cas/util/Parameters.java
@@ -1,0 +1,42 @@
+package edu.yale.its.tp.cas.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import javax.naming.InitialContext;
+import javax.naming.NameNotFoundException;
+import javax.naming.NamingException;
+import javax.servlet.FilterConfig;
+
+/**
+ * @author Matt Drees
+ */
+public class Parameters
+{
+    private static Log log = LogFactory.getLog(Parameters.class);
+
+    public static String getParameter(FilterConfig config, String parameterName) {
+        String jndiValue = jndiLookup(parameterName);
+        if (jndiValue != null)
+        {
+            return jndiValue;
+        }
+        else
+        {
+            return config.getInitParameter(parameterName);
+        }
+    }
+
+    private static String jndiLookup(String parameterName) {
+        String location = "java:comp/env/cas/" + parameterName;
+        try {
+            return (String) new InitialContext().lookup(location);
+        } catch (NameNotFoundException e) {
+            return null;
+        } catch (NamingException e) {
+            log.warn("unable to look up in jndi: " + location, e);
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
This PR contains a few changes that make this client usable by a docker-based app.

This solves two problems:
1. Docker apps typically use the same image in various environments, and use environment variables to drive environment-specific config. The client's current web.xml-based configuration makes this impossible.
2. Docker apps typically do not run with statically-assigned hostnames. So, the LogoutEchoFilter cannot be used, as it requires a static list of hostnames.

We solve the first by allowing jndi-based config (which, in wildfly, can be driven by environment variables), and the second by using a distributed cache to store logout requests instead of a static in-vm list.
